### PR TITLE
Readme instructions for pre-commit [sc-75047]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This file goes from least specific to most specific.
+# The furthest match down is the one that is used.
+# File size limit: 3 MB
+
+# Default Owners
+*                                                          @wrapbook/platform

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Change description
+
+> Description here
+
+## Type of change
+
+- [ ] Fix an issue
+- [ ] Modify existing functionality
+- [ ] Add new functionality
+- [ ] Remove functionality
+
+## Checklists
+
+### Code review
+
+- [ ] New / modified functionality has corresponding tests
+- [ ] Changes have been tested on a branch in the `app-ci` repository
+- [ ] Pull request has a descriptive title and context useful to a reviewer
+- [ ] Pull request linked to task tracker
+
+## Documentation
+
+- [ ] Relevant team documentation is up-to-date
+
+## Credits
+
+_who helped with this_

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ npm pack
 npx github-action-readme-generator-<version>.tgz
 ```
 
+### Use as a pre-commit hook in other local repositories
+
+First, copy the tgz file to the desired repository
+
+```sh
+cp -av github-action-readme-generator-<version>.tgz <root-of-other-repo>
+```
+
+Then, add the following to the `.pre-commit-config.yaml` file in that repository
+
+```yaml
+- repo: local
+  hooks:
+    - id: gha-readme-generator
+      name: gha-readme-generator
+      entry: bash -c "npx github-action-readme-generator-<version>.tgz"
+      language: system
+      pass_filenames: false
+      files: "action.yml"
+```
+
 ### Stand Alone Usage - if you have a Docker Action
 
 ```sh


### PR DESCRIPTION
- Additional instructions for current process of including the generator as a pre-commit hook
- Add PR template and codeowners file

https://app.shortcut.com/wrapbook/story/75047/add-github-action-readme-generator-to-pre-commit-hooks-for-our-actions