### PR TITLE
Add output value column [sc-76147]

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ or use none, and instead use a `.ghadocs.json` file.
 
 <!-- start outputs -->
 
-| **Output**            | **Description**                                                        |
-| --------------------- | ---------------------------------------------------------------------- |
-| **<code>test</code>** | The test output is used to test the output component of the generator. |
+| **Output**            | **Description**                                                        | **Value**                                        |
+| --------------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| **<code>test</code>** | The test output is used to test the output component of the generator. | <code>${{ steps.test_step.outputs.test }}</code> |
 
 <!-- end outputs -->
 <!-- start [.github/ghadocs/examples/] -->

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,7 @@ outputs:
   test:
     description: >
       The test output is used to test the output component of the generator.
+    value: ${{ steps.test_step.outputs.test }}
 
 runs:
   using: 'node16'

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -11,6 +11,7 @@ export interface InputType {
 }
 export interface OutputType {
   description?: string;
+  value?: string;
 }
 export interface Runs {
   using: string;

--- a/src/sections/update-outputs.ts
+++ b/src/sections/update-outputs.ts
@@ -8,7 +8,7 @@ export default function updateOutputs(token: string, inputs: Inputs): void {
 
   // Build the new README
   const content: string[] = [];
-  const markdownArray: string[][] = [['Output', 'Description']];
+  const markdownArray: string[][] = [['Output', 'Description', 'Value']];
   const vars = inputs.action.outputs;
   const tI = vars ? Object.keys(vars).length : 0;
   if (tI > 0) {
@@ -19,6 +19,7 @@ export default function updateOutputs(token: string, inputs: Inputs): void {
       const row: string[] = [
         `**\`${key.trim()}\`**`,
         values?.description?.trim().replace('\n', '<br />') ?? '',
+        values?.value ? `\`${values.value}\`` : '',
       ];
       log.debug(JSON.stringify(row));
       markdownArray.push(row);


### PR DESCRIPTION
`value` is a required field on an action's `output`. Adding this component to the Outputs table in the readme.

https://app.shortcut.com/wrapbook/story/76147/gha-readme-generator-add-value-column-for-outputs